### PR TITLE
fix for gnome3

### DIFF
--- a/lightson+.sh
+++ b/lightson+.sh
@@ -98,7 +98,7 @@ done< <(xvinfo | sed -n 's/^screen #\([0-9]\+\)$/\1/p')
 #pgrep cuts off last character
 if [ `pgrep -lc xscreensave` -ge 1 ];then
     screensaver="xscreensaver"
-elif [ `pgrep -lc gnome-screensave` -ge 1 ] || [ `pgrep -lc gnome-shel` -ge 1 ] ;then
+elif [ `pgrep -lc gnome-screensave` -ge 1 ] || [ `pgrep -lc gnome-shel` -ge 1 ] || ( [[ "$(gsettings get org.gnome.desktop.session idle-delay | sed 's/uint32 //' 2>&1)" =~ ^-?[0-9]+$ ]] && [ "$(gsettings get org.gnome.desktop.session idle-delay | sed 's/uint32 //' 2>&1)" -gt 0 ] );then
     screensaver="gnome-screensaver"
 elif [ `pgrep -lc kscreensave` -ge 1 ];then
     screensaver="kscreensaver"

--- a/lightson+.sh
+++ b/lightson+.sh
@@ -98,7 +98,7 @@ done< <(xvinfo | sed -n 's/^screen #\([0-9]\+\)$/\1/p')
 #pgrep cuts off last character
 if [ `pgrep -lc xscreensave` -ge 1 ];then
     screensaver="xscreensaver"
-elif [ `pgrep -lc gnome-screensave` -ge 1 ] || [ `pgrep -lc gnome-shel` -ge 1 ] || ( [[ "$(gsettings get org.gnome.desktop.session idle-delay | sed 's/uint32 //' 2>&1)" =~ ^-?[0-9]+$ ]] && [ "$(gsettings get org.gnome.desktop.session idle-delay | sed 's/uint32 //' 2>&1)" -gt 0 ] );then
+elif [ `pgrep -lc gnome-screensave` -ge 1 ] || [ `pgrep -lc gnome-shel` -ge 1 ] || [ `gnome-screensaver-command -q | grep -c active` -ge 1 ]; then
     screensaver="gnome-screensaver"
 elif [ `pgrep -lc kscreensave` -ge 1 ];then
     screensaver="kscreensaver"

--- a/lightson+.sh
+++ b/lightson+.sh
@@ -198,7 +198,7 @@ isAppRunning()
 
     #html5 (Firefox or Chromium full-screen)
     if [ $html5_detection == 1 ];then
-        if [[ "$activ_win_title" = *Chrome* || "$activ_win_title" = *chromium-browser* || "$activ_win_title" = *Firefox* || "$activ_win_title" = *epiphany* || "$activ_win_title" = *opera* ]];then   
+        if [[ "$activ_win_title" = *Chrome* || "$activ_win_title" = *hromium-browser* || "$activ_win_title" = *Firefox* || "$activ_win_title" = *epiphany* || "$activ_win_title" = *opera* ]];then   
             #check if firefox or chromium is running.
             if [[ `pgrep -lc chrome` -ge 1 || `pgrep -lc firefox` -ge 1 || `pgrep -lc chromium-browser` -ge 1  || `pgrep -lc opera` -ge 1 || `pgrep -lc epiphany` -ge 1 ]]; then
                 return 1

--- a/lightson+.sh
+++ b/lightson+.sh
@@ -108,7 +108,8 @@ elif [ `pgrep -lc cinnamon-screen` -ge 1 ]; then
     screensaver=cinnamon-screensaver
 else
     screensaver=""
-    echo "No screensaver detected"     
+    echo "No screensaver detected"
+    exit 1
 fi
 
 checkFullscreen()


### PR DESCRIPTION
I'm using ubuntu 14.04 LTS where the gnome-screensaver is used, but when I start lightson+.sh the comes the message, that no Screensaver is detected. (gnome-session --version: 3.9.90)
It could be possible to test for the following settings to determine whether the gnome-screensaver is used, but I don't know if this is used in older gnome versions too. If the screensaver is enabled the value (here: 300) is greater than 0:
```
bash$ gsettings get org.gnome.desktop.session idle-delay
uint32 300
```
Simulating user actions for the gnome-screensaver with dbus works just fine. It is just the screensaver recognition, that does not.