### PR TITLE
Correct spelling of "delayScreensaver"

### DIFF
--- a/lightson+.sh
+++ b/lightson+.sh
@@ -319,7 +319,7 @@ done
 
 echo "start lightsOn mainloop"
 while true; do
-    [ -f "$inhibitfile" ] && dealyScreensaver || checkFullscreen
+    [ -f "$inhibitfile" ] && delayScreensaver || checkFullscreen
     sleep $delay
 done
 


### PR DESCRIPTION
Fix a typo which causes the script to fail to delay screensaver and only print "line 322: dealyScreensaver: command not found".