### PR TITLE
Match uppercase "VLC" in window title

### DIFF
--- a/lightson+.sh
+++ b/lightson+.sh
@@ -196,7 +196,7 @@ isAppRunning() {
         fi
         
         if [ $vlc_detection == 1 ]; then
-            if [ "$activ_win_title" = *vlc* ]; then
+            if [ "$activ_win_title" = *vlc* || "$activ_win_title" = *VLC* ]; then
                 # check if vlc is running.
                 [ `pgrep -c vlc` -ge 1 ] && return 1
             fi


### PR DESCRIPTION
In VLC 2.2.1 at least, the window title contains uppercase "VLC" and not lowercase "vlc". This change makes vlc detection accept both.