### PR TITLE
Bash error fixed in line 201 (wrong brackets). Chrome uses also lower…

### DIFF
--- a/lightson+.sh
+++ b/lightson+.sh
@@ -177,7 +177,7 @@ isAppRunning() {
     
     if [ $html5_detection == 1 ]; then
         # chromium changed spelling  (c/C possible)
-        if [[ "$activ_win_title" = *Chrome* || "$activ_win_title" = *hromium* || "$activ_win_title" = *Firefox* || "$activ_win_title" = *epiphany* || "$activ_win_title" = *opera* ]]; then
+        if [[ "$activ_win_title" = *hrome* || "$activ_win_title" = *hromium* || "$activ_win_title" = *Firefox* || "$activ_win_title" = *epiphany* || "$activ_win_title" = *opera* ]]; then
             # check if firefox or chromium is running.
             [[ `pgrep -c chrome` -ge 1 || `pgrep -c firefox` -ge 1 || `pgrep -c chromium` -ge 1  || `pgrep -c opera` -ge 1 || `pgrep -c epiphany` -ge 1 ]] && return 1
         fi
@@ -198,7 +198,7 @@ isAppRunning() {
     fi
         
     if [ $vlc_detection == 1 ]; then
-        if [ "$activ_win_title" = *vlc* || "$activ_win_title" = *VLC* ]; then
+        if [[ "$activ_win_title" = *vlc* || "$activ_win_title" = *VLC* ]]; then
             # check if vlc is running.
             [ `pgrep -c vlc` -ge 1 ] && return 1
         fi


### PR DESCRIPTION
…case only window title.
I got a bash error message in line 201. The brackets have to be double brackets for the || to work.
Chromes class string is `WM_CLASS(STRING) = "google-chrome", "Google-chrome"` on my machine.
The "risk" of delaying the screensaver on another application running in fullscreen with a class string *hrome* should be very small.