### PR TITLE
fix issue #18

### DIFF
--- a/lightson+
+++ b/lightson+
@@ -150,7 +150,7 @@ isAppRunning() {
         [ "$chromium_flash_detection" = 1 ] && [ `pgrep -fc "chrome --type=ppapi"` -ge 1 ] && return 0
         [ "$html5_detection" = 1 ] && [ `pgrep -c chrome` -ge 1 ] && checkAudio "chrom" && return 0
         ;;
-    *Firefox*)
+    *[Ff]irefox*)
         [ "$html5_detection" = 1 ] && [ `pgrep -c firefox` -ge 1 ] && checkAudio "firefox" && return 0
         ;;
     *opera*)


### PR DESCRIPTION
Tested with fullscreen Netflix on Firefox 68 (Arch Linux) - now LightsOnPlus works as expected, inhibiting screensaver on fullscreen video.
Credit to @aufkrawall (https://github.com/devkral/lightsonplus/issues/18#issuecomment-518303953)