### PR TITLE
Skip null window id

### DIFF
--- a/lightson+
+++ b/lightson+
@@ -122,12 +122,12 @@ checkFullscreen() {
         top_win_id=${top_win_id:0:9} # eliminate potentially trailing spaces
 
         # Check if Active Window (the foremost window) is in fullscreen state
-        if [ ${#active_win_id} -ge 3 ]; then
+        if [ ${#active_win_id} -ge 3 ] && [ "$active_win_id" != 0x0 ]; then
             isActiveWinFullscreen=`DISPLAY=$realdisp.${display} xprop -id $active_win_id | grep _NET_WM_STATE_FULLSCREEN`
         else
             isActiveWinFullscreen=""
         fi
-        if [ ${#top_win_id} -ge 3 ]; then
+        if [ ${#top_win_id} -ge 3 ] && [ "$top_win_id" != 0x0 ]; then
             isTopWinFullscreen=`DISPLAY=$realdisp.${display} xprop -id $top_win_id | grep _NET_WM_STATE_FULLSCREEN`
         else
             isTopWinFullscreen=""


### PR DESCRIPTION
If xprop returns a 0x0 window id, we'll just skip it!